### PR TITLE
添加标签云页面page-tags.php

### DIFF
--- a/page-tags.php
+++ b/page-tags.php
@@ -48,7 +48,7 @@ $this->need('header.php'); ?>
             <?php $this->widget('Widget_Metas_Tag_Cloud','sort=name&ignoreZeroCount=1&desc=0')->to($tag);$max = 0; ?>
             <?php while ($tag->next()) if ($tag->count > $max) $max = $tag->count; ?>
             <?php while ($tag->next()): ?>
-                <a href="<?php $tag->permalink(); ?>" style="font-size: <?php echo round($tag->count/$max*15+15,2); ?>px;color: #<?php $color = round(75-54*$tag->count/$max);echo $color.$color.$color; ?>"><?php $tag->name(); ?></a>
+                <a href="<?php $tag->permalink(); ?>" style="font-size: <?php echo round($tag->count/$max*15+15,2); ?>px;color: #<?php $color = base_convert(round(117-84*$tag->count/$max),10,16);echo $color.$color.$color; ?>"><?php $tag->name(); ?></a>
             <?php endwhile; ?>
             </div>
         </div>

--- a/page-tags.php
+++ b/page-tags.php
@@ -48,7 +48,7 @@ $this->need('header.php'); ?>
             <?php $this->widget('Widget_Metas_Tag_Cloud','sort=name&ignoreZeroCount=1&desc=0')->to($tag);$max = 0; ?>
             <?php while ($tag->next()) if ($tag->count > $max) $max = $tag->count; ?>
             <?php while ($tag->next()): ?>
-                <a href="<?php $tag->permalink(); ?>" style="font-size: <?php echo round($tag->count/$max*15+15,2); ?>px; color: #<?php $color = round(75-54*$tag->count/$max);echo $color.$color.$color; ?>"><?php $tag->name(); ?></a>
+                <a href="<?php $tag->permalink(); ?>" style="font-size: <?php echo round($tag->count/$max*15+15,2); ?>px;color: #<?php $color = round(75-54*$tag->count/$max);echo $color.$color.$color; ?>"><?php $tag->name(); ?></a>
             <?php endwhile; ?>
             </div>
         </div>

--- a/page-tags.php
+++ b/page-tags.php
@@ -48,7 +48,7 @@ $this->need('header.php'); ?>
             <?php $this->widget('Widget_Metas_Tag_Cloud','sort=name&ignoreZeroCount=1&desc=0')->to($tag);$max = 0; ?>
             <?php while ($tag->next()) if ($tag->count > $max) $max = $tag->count; ?>
             <?php while ($tag->next()): ?>
-                <a href="<?php $tag->permalink(); ?>" style="font-size: <?php echo round($tag->count/$max*15+15,2); ?>px;color: #<?php $color = round(75-54*$tag->count/$max);echo $color.$color.$color; ?>"><?php $tag->name(); ?></a>
+                <a href="<?php $tag->permalink(); ?>" style="font-size: <?php echo round($tag->count/$max*15+15,2); ?>px; color: #<?php $color = round(75-54*$tag->count/$max);echo $color.$color.$color; ?>"><?php $tag->name(); ?></a>
             <?php endwhile; ?>
             </div>
         </div>

--- a/page-tags.php
+++ b/page-tags.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * 标签云页面
+ *
+ * @package custom
+ */
+$this->need('header.php'); ?>
+
+<style>
+    #bottom{
+        position: relative;
+    }
+    @media screen and (max-width: 480px) {
+        .material-tagscloud{
+            margin: 6em 2em 0;
+        }
+    }
+    .material-tagscloud a{
+        text-decoration:none;
+        padding: 1px 9px;
+        margin: 9px 1px;
+        line-height: 40px;
+        white-space: nowrap;
+        transition: .6s;
+        opacity: .85;
+    }
+    .material-tagscloud a:hover{
+        transition: .6s;
+        opacity: 1;
+        background: #FAFAFA;
+        box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 3px 1px -2px rgba(0,0,0,.2), 0 1px 5px 0 rgba(0,0,0,.12);
+    }
+</style>
+
+<div class="material-layout mdl-js-layout has-drawer is-upgraded">
+    <main class="material-layout__content" id="main">
+
+        <!-- Top Anchor -->
+        <div id="top"></div>
+
+        <!-- Hamburger Button -->
+        <button class="MD-burger-icon sidebar-toggle">
+            <span id="MD-burger-id" class="MD-burger-layer"></span>
+        </button>
+
+        <div class=" material-tagscloud">
+            <div class="material-post mdl-grid">
+            <?php $this->widget('Widget_Metas_Tag_Cloud','sort=name&ignoreZeroCount=1&desc=0')->to($tag);$max = 0; ?>
+            <?php while ($tag->next()) if ($tag->count > $max) $max = $tag->count; ?>
+            <?php while ($tag->next()): ?>
+                <a href="<?php $tag->permalink(); ?>" style="font-size: <?php echo round($tag->count/$max*15+15,2); ?>px;color: #<?php $color = round(75-54*$tag->count/$max);echo $color.$color.$color; ?>"><?php $tag->name(); ?></a>
+            <?php endwhile; ?>
+            </div>
+        </div>
+
+        <?php include('sidebar.php'); ?>
+        <?php include('footer.php'); ?>


### PR DESCRIPTION
样式是hexo-theme-material那边的。
字体大小和颜色深浅的系数是`$tag->count/$max`，`$max`是所有标签中文章数最大值，感觉这样效果会比总文章数当分母好一点（那样得出来的值太小了QAQ）。
颜色深浅的公式是[这篇文章](https://blog.csdn.net/SigridW/article/details/39453211)里的，浅的颜色为`#757575`，深的颜色为`#212121`（这两个参数也是hexo-theme-material那边的)。
效果：
![](https://raw.githubusercontent.com/ZigZagK/ZigZagK.github.io/master/Material%E6%A0%87%E7%AD%BE%E4%BA%91.jpeg)
~~很抱歉我不小心commit了两次QAQ。~~
又改了一下……之前那个计算颜色的时候没有用16进制（我是zz）。