### PR TITLE
[Fixed] disqusjs: Special characters in siteName

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -200,7 +200,7 @@
             <script type="<?php getScriptType() ?>" id="disqus_js">
                 var dsqjs = new DisqusJS({
                     shortname: '<?php getThemeOptions("DisqusShortname", true) ?>',
-                    siteName: '<?php getThemeOptions("DisqusSiteName", true) ?>',
+                    siteName: <?php echo json_encode(getThemeOptions("DisqusSiteName")) ?>,
                     identifier: '<?php $this->cid() ?>',
                     url: '<?php $this->permalink() ?>',
                     api: '<?php getThemeOptions("DisqusApi", true) ?>',


### PR DESCRIPTION
There might be some special characters in siteName, such as quotation marks.
Without proper escape characters, they might be interpreted as controlling
characters.

So we use PHP's json_encode function to handle this string. It will emit
escape characters automatically.

Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>

---

In my case, my siteName is `Flygoat's Blog`. The original code generated js like:

```
var dsqjs = new DisqusJS({
  shortname: 'flygoats-blog',
  siteName: 'FlyGoat's Blog',
  identifier: '147',
  url: 'https://blog.flygoat.com/archives/147/',
  api: 'https://disqus.skk.moe/disqus/',
  apikey: '##### SECRET #####',
  admin: 'flygoat',
  adminLabel: 'mod'
});
```
Here `'s` was interpreted  as the end of the string, and discus failed to load.

After this PR:

```
var dsqjs = new DisqusJS({
  shortname: 'flygoats-blog',
  siteName: 'FlyGoat\'s Blog',
  identifier: '147',
  url: 'https://blog.flygoat.com/archives/147/',
  api: 'https://disqus.skk.moe/disqus/',
  apikey: '##### SECRET #####',
  admin: 'flygoat',
  adminLabel: 'mod'
});
```

Thanks.