### PR TITLE
[Fixed] Typecho editor previews don't show content

### DIFF
--- a/index.php
+++ b/index.php
@@ -295,5 +295,5 @@ $this->need('header.php'); ?>
 
             </div>
 
-            <?php include('sidebar.php'); ?>
-            <?php include('footer.php'); ?>
+            <?php $this->need('sidebar.php'); ?>
+            <?php $this->need('footer.php'); ?>

--- a/page-links.php
+++ b/page-links.php
@@ -121,5 +121,5 @@ $this->need('header.php'); ?>
         </div>
 
 
-        <?php include('sidebar.php'); ?>
-        <?php include('footer.php'); ?>
+        <?php $this->need('sidebar.php'); ?>
+        <?php $this->need('footer.php'); ?>

--- a/page-tags.php
+++ b/page-tags.php
@@ -53,5 +53,5 @@ $this->need('header.php'); ?>
             </div>
         </div>
 
-        <?php include('sidebar.php'); ?>
-        <?php include('footer.php'); ?>
+        <?php $this->need('sidebar.php'); ?>
+        <?php $this->need('footer.php'); ?>

--- a/page-timeline-material.php
+++ b/page-timeline-material.php
@@ -424,5 +424,5 @@ $this->need('header.php'); ?>
     <?php endwhile; ?>
 </section>
 
-<?php include('sidebar.php'); ?>
-<?php include('footer.php'); ?>
+<?php $this->need('sidebar.php'); ?>
+<?php $this->need('footer.php'); ?>

--- a/page-timeline-voez.php
+++ b/page-timeline-voez.php
@@ -149,5 +149,5 @@ $this->need('header.php'); ?>
     <?php endwhile; ?>
 </ul>
 
-<?php include('sidebar.php'); ?>
-<?php include('footer.php'); ?>
+<?php $this->need('sidebar.php'); ?>
+<?php $this->need('footer.php'); ?>

--- a/page.php
+++ b/page.php
@@ -113,7 +113,7 @@
                     </div>
 
                     <!-- Article comments -->
-                    <?php include('comments.php'); ?>
+                    <?php $this->need('comments.php'); ?>
                 </div>
 
                 <!-- theNext thePrev button -->
@@ -129,5 +129,5 @@
                 </nav>
             </div>
 
-            <?php include('sidebar.php'); ?>
-            <?php include('footer.php'); ?>
+            <?php $this->need('sidebar.php'); ?>
+            <?php $this->need('footer.php'); ?>

--- a/post.php
+++ b/post.php
@@ -137,6 +137,11 @@
                         </button>', 'tagClass' => 'prev-content')); ?>
                 </nav>
             </div>
-
+            <?php if(isset($this->parameter->preview) && $this->parameter->preview): ?>
+              <!-- Fix typecho preview content -->
+              <script>
+                document.getElementById("post-content").classList.remove("out");
+              </script>
+            <?php endif; ?>
             <?php include('sidebar.php'); ?>
             <?php include('footer.php'); ?>

--- a/post.php
+++ b/post.php
@@ -121,7 +121,7 @@
                     </div>
 
                     <!-- Article comments -->
-                    <?php include('comments.php'); ?>
+                    <?php $this->need('comments.php'); ?>
 
                 </div>
 
@@ -137,11 +137,6 @@
                         </button>', 'tagClass' => 'prev-content')); ?>
                 </nav>
             </div>
-            <?php if(isset($this->parameter->preview) && $this->parameter->preview): ?>
-              <!-- Fix typecho preview content -->
-              <script>
-                document.getElementById("post-content").classList.remove("out");
-              </script>
-            <?php endif; ?>
-            <?php include('sidebar.php'); ?>
-            <?php include('footer.php'); ?>
+
+            <?php $this->need('sidebar.php'); ?>
+            <?php $this->need('footer.php'); ?>


### PR DESCRIPTION
由于 php include的特性
https://github.com/idawnlight/typecho-theme-material/blob/cefcfd33fc04306f0831917b4116d3d626a5537e/post.php#L142
会优先加载 /admin/footer.php 导致主题 Javascript 无法被加载，故文章内容无法显示
不知道是不是有意为之，预览好像也没有加载 MDL 等其他 js 的必要，所以这里加了一小段 js 移除文章内容的透明度。 
Related to #101
Fixed #101