### PR TITLE
修复页面底部在文章和页面下仍不在底部的问题

### DIFF
--- a/page.php
+++ b/page.php
@@ -3,7 +3,6 @@
 <div class="material-layout  mdl-js-layout has-drawer is-upgraded">
 
     <main class="material-layout__content" id="main">
-      <div class="min-height-for-footer">
         <div id="top"></div>
         <!-- Hamburger Button -->
         <button class="MD-burger-icon sidebar-toggle">
@@ -11,6 +10,7 @@
         </button>
 
         <!-- Post module -->
+        <div class="min-height-for-footer">
         <div class="material-post_container">
             <div class="material-post mdl-grid">
 
@@ -130,5 +130,6 @@
                 </nav>
             </div>
             </div>
+        </div>
             <?php $this->need('sidebar.php'); ?>
             <?php $this->need('footer.php'); ?>

--- a/post.php
+++ b/post.php
@@ -3,7 +3,6 @@
 <div class="material-layout  mdl-js-layout has-drawer is-upgraded">
 
     <main class="material-layout__content" id="main">
-      <div class="min-height-for-footer">
         <div id="top"></div>
         <!-- Hamburger Button -->
         <button class="MD-burger-icon sidebar-toggle">
@@ -11,6 +10,7 @@
         </button>
 
         <!-- Post module -->
+        <div class="min-height-for-footer">
         <div class="material-post_container">
             <div class="material-post mdl-grid">
 
@@ -139,6 +139,7 @@
                 </nav>
             </div>
             </div>
+        </div>
 
             <?php $this->need('sidebar.php'); ?>
             <?php $this->need('footer.php'); ?>


### PR DESCRIPTION
原 issue #72 
修复了 #107 中两处未被完全修复的部分