### PR TITLE
Fix regex matching issue on search pages with Lazyload enabled

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -226,7 +226,7 @@ function showThumbnail($widget)
 
     if (getThemeOptions("FetchFirstImageRegex", false, '0') == '0') {
         global $t;
-        if (in_array("Lazyload", getThemeOptions("switch")) && method_exists($t,'is') && !$t->is('index')) {
+        if (in_array("Lazyload", getThemeOptions("switch")) && method_exists($t,'is') && !$t->is('index') && !$t->is('search')) {
             if (preg_match_all('/\<img.*?data-original\=\"(.*?)\"[^>]*>/i', $widget->content, $thumbUrl)) {
                 $result = $thumbUrl[1][0];
             }


### PR DESCRIPTION
添加了一个条件判断以修复文章缩略图的正则表达式匹配功能在Lazyload启用的情况下在搜索页面（包括类别/原生搜索等）不起作用的问题。